### PR TITLE
Modify snakemake setup to init micromamba shell

### DIFF
--- a/Kenta_Stuff/snakemake_stuff/setup.sh
+++ b/Kenta_Stuff/snakemake_stuff/setup.sh
@@ -7,4 +7,5 @@ BIN_DIR="$INSTALL_DIR/bin"
 
 export PATH="$BIN_DIR:$PATH"
 
+eval "$(micromamba shell hook --shell bash)"
 micromamba activate codex-env


### PR DESCRIPTION
## Summary
- init micromamba shell before activation in `setup.sh`

## Testing
- `bash -n Kenta_Stuff/snakemake_stuff/setup.sh`
- `source Kenta_Stuff/snakemake_stuff/setup.sh`

------
https://chatgpt.com/codex/tasks/task_e_685f14d0cc848326800f2aa49117ebcf