### PR TITLE
Use only plus strand sampling

### DIFF
--- a/Kenta_Stuff/Scripts/chip_seq.py
+++ b/Kenta_Stuff/Scripts/chip_seq.py
@@ -188,12 +188,8 @@ def sample_genome(fasta, genome_pmfs):
         picked_chrom = random.choices(chroms, weights=biases)[0]
         sample_index = sample_from_bins(genome_pmfs[picked_chrom], 1)[0]
 
-        strand = random.choice(['+', '-'])
-        if strand == '+':
-            coords = list(range(sample_index, sample_index + k))
-        else:
-            coords = list(range(sample_index + k - 1, sample_index - 1, -1))
-
+        strand = '+'
+        coords = list(range(sample_index, sample_index + k))
         reads_dict[picked_chrom].append((strand, coords))
 
     # print(json.dumps(reads_dict, indent=4))
@@ -202,15 +198,11 @@ def sample_genome(fasta, genome_pmfs):
 def sample_to_fasta(exp, fasta):
     """Convert sampled indices into FASTA format"""
 
-    complement = {'A': 'T', 'T': 'A', 'C': 'G', 'G': 'C', 'N': 'N'}
     frag_num = 1
 
     for id, seq in LIB.read_fasta(fasta):
         for strand, coords in exp[id]:
             dna = [seq[index] for index in coords]
-
-            if strand == '-':
-                dna = [complement.get(base, 'N') for base in dna]
 
             print(f'>read_{frag_num}:{id}:{strand}')
             print(''.join(dna))


### PR DESCRIPTION
## Summary
- adjust chip_seq sampling so reads are always taken from the plus strand
- simplify FASTA output routine

## Testing
- `python -m py_compile Kenta_Stuff/Scripts/chip_seq.py`
- `python Kenta_Stuff/Scripts/chip_seq.py --fasta Michelle_Stuff/1Sicer2/random_genome_1.fa.gz --coverage 0.1 --fragment_length 20 --num_bg_peaks 1 --num_fg_peaks 1 --peak_broadness 9 --tallness 10 | head`

------
https://chatgpt.com/codex/tasks/task_e_6882acde53f0832684e1cdeab0eeedf9