### PR TITLE
Add PMF variance export

### DIFF
--- a/Kenta_Stuff/Scripts/copy_chip_seq.py
+++ b/Kenta_Stuff/Scripts/copy_chip_seq.py
@@ -66,6 +66,8 @@ parser.add_argument('--gc_bias_params', type=str, default=None,
     help='CSV file for GC bias lookup table')
 parser.add_argument('--seed', type=int, default=42,
     help='Random seed for reproducible TF peak placement')
+parser.add_argument('--pmf_csv', type=str, default=None,
+    help='Path to CSV file storing PMF and variance per bin')
 
 args, _ = parser.parse_known_args()
 
@@ -83,6 +85,19 @@ accessibility_bed = args.accessibility_bed
 acc_weight = args.acc_weight
 gc_bias_params = args.gc_bias_params
 seed = args.seed
+pmf_csv = args.pmf_csv
+
+if not pmf_csv and fasta:
+    base = os.path.splitext(os.path.basename(fasta))[0]
+    pmf_csv = f'{base}_pmf.csv'
+
+"""PMF CSV Structure
+___________________
+
+- bin_idx: zero-based index of fragment start bin
+- pmf: probability assigned to the bin
+- variance: pmf * (1 - pmf)
+"""
 
 
 '''
@@ -238,6 +253,23 @@ def create_pmf_all_chroms(fasta, peak_broadness, tallness):
         pmf = combined / combined.sum()
         genome_pmfs[chrom_id] = pmf.tolist()
     return genome_pmfs
+
+def pmf_variance(pmf: List[float]) -> List[float]:
+    """Return variance for each bin assuming Bernoulli trials."""
+    arr = np.asarray(pmf, dtype=float)
+    var = arr * (1 - arr)
+    return var.tolist()
+
+def write_pmf_csv(genome_pmfs: Dict[str, List[float]], path: str) -> None:
+    """Write PMF and variance arrays to CSV."""
+    rows = []
+    for pmf in genome_pmfs.values():
+        arr = np.asarray(pmf, dtype=float)
+        var = arr * (1 - arr)
+        for idx, (p, v) in enumerate(zip(arr, var)):
+            rows.append((idx, p, v))
+    df = pd.DataFrame(rows, columns=['bin_idx', 'pmf', 'variance'])
+    df.to_csv(path, index=False)
 
 def chrom_bias(fasta):
     """
@@ -396,6 +428,8 @@ Below code will print the FASTA for the reads generated from experiment
 
 if fasta:
     genome_pmf = create_pmf_all_chroms(fasta, peak_broadness, tallness)
+    if pmf_csv:
+        write_pmf_csv(genome_pmf, pmf_csv)
     exp = sample_genome(fasta, genome_pmf)
     # print(json.dumps(genome_pmf, indent=4)) # for debugging
     # print(json.dumps(exp, indent=4)) # for debugging


### PR DESCRIPTION
## Summary
- export per-bin PMF and variance to CSV
- support `--pmf_csv` argument with default based on FASTA basename
- document CSV format in script

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6883fcc3a6148326b6d273a5386f3e8b