### PR TITLE
Refactor to avoid global state in copy_chip_seq

### DIFF
--- a/tests/test_bias_pmfs.py
+++ b/tests/test_bias_pmfs.py
@@ -10,13 +10,13 @@ from Kenta_Stuff.Scripts import copy_chip_seq as cs
 
 def test_bias_pmfs():
     seq = 'ACGTACGTACGT'
-    cs.k = 4
-    length = len(seq) - cs.k + 1
+    k = 4
+    length = len(seq) - k + 1
     tf_bias = cs.build_tf_bias_pmf(length, [2, 6], sigma=1.0, enrichment=0.5)
     assert tf_bias.shape[0] == length
     np.testing.assert_almost_equal(tf_bias.sum(), 1.0)
 
-    gc_bias = cs.build_gc_bias_pmf(seq, {'csv': 'data/gc_bias_example.csv'})
+    gc_bias = cs.build_gc_bias_pmf(seq, {'csv': 'data/gc_bias_example.csv'}, k)
     assert gc_bias.shape[0] == length
     np.testing.assert_almost_equal(gc_bias.sum(), 1.0)
 


### PR DESCRIPTION
## Summary
- refactor `copy_chip_seq.py` functions to take required values as parameters
- update call sites to pass arguments explicitly
- adjust `build_gc_bias_pmf` signature
- update unit tests for new function interfaces

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6884145e6e4883269555d4881c8ef579