### PR TITLE
Fix PMF initialization bug in copy_chip_seq

### DIFF
--- a/Kenta_Stuff/Scripts/copy_chip_seq.py
+++ b/Kenta_Stuff/Scripts/copy_chip_seq.py
@@ -184,11 +184,11 @@ def build_accessibility_bias_pmf(length: int, accessibility_bed: str,
     return bias
 
 def create_pmf(chrom_len: int, k: int) -> List[float]:
-    """Initialize PMF array with zeros for one chromosome."""
+    """Initialize uniform PMF array for one chromosome."""
 
     num_bins = chrom_len - k + 1
 
-    pmf = [0] * num_bins
+    pmf = [1] * num_bins
 
     return pmf
 


### PR DESCRIPTION
## Summary
- ensure PMF base distribution is uniform instead of zeroed
- confirm script now outputs FASTA reads and PMF CSV
- run repository tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688996bc382883268c649904a89474c6