### PR TITLE
Add reminder to consult local README before tasks

### DIFF
--- a/Kenta_Stuff/chipseq_pipeline/AGENTS.md
+++ b/Kenta_Stuff/chipseq_pipeline/AGENTS.md
@@ -3,6 +3,9 @@
 This file governs contributions within `Kenta_Stuff/chipseq_pipeline`. Follow
 the rules in `../AGENTS.md` unless explicitly overridden below.
 
+## Task Initiation
+- Before starting any task, consult the nearest README.md in your current directory to follow directory-specific instructions.
+
 ## Testing
 - Ensure `source ../snakemake_stuff/setup.sh` has been executed.
 - Run `pytest tests` after making changes.


### PR DESCRIPTION
## Summary
- advise contributors to read the nearest README before starting work in chipseq pipeline

## Testing
- `tail -n 20 /tmp/setup.log`
- `pytest tests`


------
https://chatgpt.com/codex/tasks/task_e_6896e62f9c8c8326a2bf8017ea097961